### PR TITLE
Fix OnAcceleratedPaint2() not being called when there's no new texture

### DIFF
--- a/libcef_dll/cpptoc/render_handler_cpptoc.cc
+++ b/libcef_dll/cpptoc/render_handler_cpptoc.cc
@@ -339,8 +339,6 @@ render_handler_on_accelerated_paint2(struct _cef_render_handler_t* self,
                                      int new_texture) {
   shutdown_checker::AssertNotShutdown();
 
-  // AUTO-GENERATED CONTENT - DELETE THIS COMMENT BEFORE MODIFYING
-
   DCHECK(self);
   if (!self)
     return;
@@ -353,8 +351,8 @@ render_handler_on_accelerated_paint2(struct _cef_render_handler_t* self,
   if (dirtyRectsCount > 0 && !dirtyRects)
     return;
   // Verify param: shared_handle; type: simple_byaddr
-  DCHECK(shared_handle);
-  if (!shared_handle)
+  DCHECK(!new_texture || shared_handle);
+  if (new_texture && !shared_handle)
     return;
 
   // Translate param: dirtyRects; type: simple_vec_byref_const

--- a/libcef_dll/ctocpp/render_handler_ctocpp.cc
+++ b/libcef_dll/ctocpp/render_handler_ctocpp.cc
@@ -277,15 +277,13 @@ void CefRenderHandlerCToCpp::OnAcceleratedPaint2(CefRefPtr<CefBrowser> browser,
   if (CEF_MEMBER_MISSING(_struct, on_accelerated_paint2))
     return;
 
-  // AUTO-GENERATED CONTENT - DELETE THIS COMMENT BEFORE MODIFYING
-
   // Verify param: browser; type: refptr_diff
   DCHECK(browser.get());
   if (!browser.get())
     return;
   // Verify param: shared_handle; type: simple_byaddr
-  DCHECK(shared_handle);
-  if (!shared_handle)
+  DCHECK(!new_texture || shared_handle);
+  if (new_texture && !shared_handle)
     return;
 
   // Translate param: dirtyRects; type: simple_vec_byref_const


### PR DESCRIPTION
<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Make sure you’ve read the contribution guidelines here: https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst -->

### Description
This pull request fixes libcef_dll wrapped calls of OnAcceleratedPaint2() failing parameter checks if _shared_handle_ is null even when _new_texture_ is false (where this is expected). It's pretty much just adjusting the check to how it was in the initial on-accelerated-paint2 branch.

### Motivation and Context
Without this change, OnAcceleratedPaint2() is only called when the texture changed. This currently does not appear to be a problem for obs-browser, admittedly, but since it silently fails in release builds and for the sake of correctness, I believe it's worth fixing.
It might also help in the future when there's going to be some kind of compositing going on (like overlaying PET_POPUP elements as there's a todo-comment for).

And while I don't expect this to be intended or supported use in any way, I've been making use of this CEF fork in my own project. If possible I'd like to avoid maintaining a fork on top of a fork for a couple of changed lines, but I realize I'm on my own making use of your work here.

### How Has This Been Tested?
I've tested the change on Windows 10 with obs-browser, as well as in my own project ([Desktop+ Browser](https://github.com/elvissteinjr/DesktopPlusBrowser)), by checking if the browser output still works while making sure hardware acceleration and OnAcceleratedPaint2() is being used. 

As there are no functional changes for obs-browser, there's not much of an effect there right now, except that OnAcceleratedPaint2() gets called for every frame update again (but always just returns when new_texture is false right now).

### Types of changes
<!--- What types of changes does your PR introduce? Uncomment all that apply -->
- Bug fix (non-breaking change which fixes an issue)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been run through [clang-format](https://github.com/obsproject/obs-studio/blob/master/.clang-format). (I assume that wouldn't apply to CEF's code?)
- [x] I have read the [**contributing** document](https://github.com/obsproject/obs-studio/blob/master/CONTRIBUTING.rst).
- [x] My code is not on the master branch.
- [x] The code has been tested.
- [x] All commit messages are properly formatted and commits squashed where appropriate.
- [x] I have included updates to all appropriate documentation. (not that there is any)
